### PR TITLE
Feature/multi sign

### DIFF
--- a/dsse/sign.go
+++ b/dsse/sign.go
@@ -166,7 +166,7 @@ Any domain specific validation such as parsing the decoded body and
 validating the payload type is left out to the caller.
 Verify returns a list of accepted keys each including a keyid, public and signiture of the accepted provider keys.
 */
-func (es *envelopeSigner) Verify(e *Envelope) ([]AccesptedKey, error) {
+func (es *envelopeSigner) Verify(e *Envelope) ([]AcceptedKeys, error) {
 	return es.ev.Verify(e)
 }
 

--- a/dsse/sign.go
+++ b/dsse/sign.go
@@ -166,7 +166,7 @@ Any domain specific validation such as parsing the decoded body and
 validating the payload type is left out to the caller.
 Verify returns a list of accepted keys each including a keyid, public and signiture of the accepted provider keys.
 */
-func (es *envelopeSigner) Verify(e *Envelope) ([]AcceptedKeys, error) {
+func (es *envelopeSigner) Verify(e *Envelope) ([]AcceptedKey, error) {
 	return es.ev.Verify(e)
 }
 

--- a/dsse/sign.go
+++ b/dsse/sign.go
@@ -78,7 +78,7 @@ type SignVerifier interface {
 }
 
 // EnvelopeSigner creates signed Envelopes.
-type envelopeSigner struct {
+type EnvelopeSigner struct {
 	providers []SignVerifier
 	ev        *envelopeVerifier
 }
@@ -88,7 +88,7 @@ NewEnvelopeSigner creates an EnvelopeSigner that uses 1+ Signer
 algorithms to sign the data.
 Creates a verifier with threshold=1, at least one of the providers must validate signitures successfully.
 */
-func NewEnvelopeSigner(p ...SignVerifier) (*envelopeSigner, error) {
+func NewEnvelopeSigner(p ...SignVerifier) (*EnvelopeSigner, error) {
 	return NewMultiEnvelopeSigner(1, p...)
 }
 
@@ -98,7 +98,7 @@ algorithms to sign the data.
 Creates a verifier with threshold.
 threashold indicates the amount of providers that must validate the envelope.
 */
-func NewMultiEnvelopeSigner(threshold int, p ...SignVerifier) (*envelopeSigner, error) {
+func NewMultiEnvelopeSigner(threshold int, p ...SignVerifier) (*EnvelopeSigner, error) {
 	var providers []SignVerifier
 
 	for _, sv := range p {
@@ -121,7 +121,7 @@ func NewMultiEnvelopeSigner(threshold int, p ...SignVerifier) (*envelopeSigner, 
 		return nil, err
 	}
 
-	return &envelopeSigner{
+	return &EnvelopeSigner{
 		providers: providers,
 		ev:        ev,
 	}, nil
@@ -133,7 +133,7 @@ Returned is an envelope as defined here:
 https://github.com/secure-systems-lab/dsse/blob/master/envelope.md
 One signature will be added for each Signer in the EnvelopeSigner.
 */
-func (es *envelopeSigner) SignPayload(payloadType string, body []byte) (*Envelope, error) {
+func (es *EnvelopeSigner) SignPayload(payloadType string, body []byte) (*Envelope, error) {
 	var e = Envelope{
 		Payload:     base64.StdEncoding.EncodeToString(body),
 		PayloadType: payloadType,
@@ -166,7 +166,7 @@ Any domain specific validation such as parsing the decoded body and
 validating the payload type is left out to the caller.
 Verify returns a list of accepted keys each including a keyid, public and signiture of the accepted provider keys.
 */
-func (es *envelopeSigner) Verify(e *Envelope) ([]AcceptedKey, error) {
+func (es *EnvelopeSigner) Verify(e *Envelope) ([]AcceptedKey, error) {
 	return es.ev.Verify(e)
 }
 

--- a/dsse/sign.go
+++ b/dsse/sign.go
@@ -80,7 +80,7 @@ type SignVerifier interface {
 // EnvelopeSigner creates signed Envelopes.
 type envelopeSigner struct {
 	providers []SignVerifier
-	ev        *envelopeMultiVerifier
+	ev        *envelopeVerifier
 }
 
 /*

--- a/dsse/sign.go
+++ b/dsse/sign.go
@@ -95,7 +95,8 @@ func NewEnvelopeSigner(p ...SignVerifier) (*envelopeSigner, error) {
 /*
 NewMultiEnvelopeSigner creates an EnvelopeSigner that uses 1+ Signer
 algorithms to sign the data.
-Creates a verifier with threshold at least threshold amount of the providers must validate signitures successfully.
+Creates a verifier with threshold.
+threashold indicates the amount of providers that must validate the envelope.
 */
 func NewMultiEnvelopeSigner(threshold int, p ...SignVerifier) (*envelopeSigner, error) {
 	var providers []SignVerifier

--- a/dsse/sign_test.go
+++ b/dsse/sign_test.go
@@ -1,6 +1,7 @@
 package dsse
 
 import (
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/sha256"
@@ -33,39 +34,39 @@ func TestPAE(t *testing.T) {
 
 type nilsigner int
 
-func (n nilsigner) Sign(data []byte) ([]byte, string, error) {
-	return data, "nil", nil
+func (n nilsigner) Sign(data []byte) ([]byte, error) {
+	return data, nil
 }
 
-func (n nilsigner) Verify(keyID string, data, sig []byte) error {
-
-	if keyID == "nil" {
-		if len(data) != len(sig) {
-			return errLength
-		}
-
-		for i := range data {
-			if data[i] != sig[i] {
-				return errVerify
-			}
-		}
-
-		return nil
+func (n nilsigner) Verify(data, sig []byte) error {
+	if len(data) != len(sig) {
+		return errLength
 	}
-	return ErrUnknownKey
+
+	for i := range data {
+		if data[i] != sig[i] {
+			return errVerify
+		}
+	}
+
+	return nil
+}
+
+func (n nilsigner) KeyID() (string, error) {
+	return "nil", nil
+}
+
+func (n nilsigner) Public() crypto.PublicKey {
+	return "nil-public"
 }
 
 type nullsigner int
 
-func (n nullsigner) Sign(data []byte) ([]byte, string, error) {
-	return data, "null", nil
+func (n nullsigner) Sign(data []byte) ([]byte, error) {
+	return data, nil
 }
 
-func (n nullsigner) Verify(keyID string, data, sig []byte) error {
-	if keyID != "null" {
-		return ErrUnknownKey
-	}
-
+func (n nullsigner) Verify(data, sig []byte) error {
 	if len(data) != len(sig) {
 		return errLength
 	}
@@ -77,40 +78,62 @@ func (n nullsigner) Verify(keyID string, data, sig []byte) error {
 	}
 
 	return nil
+}
+
+func (n nullsigner) KeyID() (string, error) {
+	return "null", nil
+}
+
+func (n nullsigner) Public() crypto.PublicKey {
+	return "null-public"
 }
 
 type errsigner int
 
-func (n errsigner) Sign(data []byte) ([]byte, string, error) {
-	return nil, "", fmt.Errorf("signing error")
+func (n errsigner) Sign(data []byte) ([]byte, error) {
+	return nil, fmt.Errorf("signing error")
 }
 
-func (n errsigner) Verify(keyID string, data, sig []byte) error {
+func (n errsigner) Verify(data, sig []byte) error {
 	return errVerify
+}
+
+func (n errsigner) KeyID() (string, error) {
+	return "err", nil
+}
+
+func (n errsigner) Public() crypto.PublicKey {
+	return "err-public"
 }
 
 type errverifier int
 
-var errVerify = fmt.Errorf("test err verify")
+var errVerify = fmt.Errorf("Accepted signitures do not match threshold, Found: 0, Expected 1")
+var errThreshold = fmt.Errorf("Invalid threshold")
 
-func (n errverifier) Sign(data []byte) ([]byte, string, error) {
-	return data, "err", nil
+func (n errverifier) Sign(data []byte) ([]byte, error) {
+	return data, nil
 }
 
-func (n errverifier) Verify(keyID string, data, sig []byte) error {
+func (n errverifier) Verify(data, sig []byte) error {
 	return errVerify
+}
+
+func (n errverifier) KeyID() (string, error) {
+	return "err", nil
+}
+
+func (n errverifier) Public() crypto.PublicKey {
+	return "err-public"
 }
 
 type badverifier int
 
-func (n badverifier) Sign(data []byte) ([]byte, string, error) {
-	return append(data, byte(0)), "bad", nil
+func (n badverifier) Sign(data []byte) ([]byte, error) {
+	return append(data, byte(0)), nil
 }
 
-func (n badverifier) Verify(keyID string, data, sig []byte) error {
-	if keyID != "bad" {
-		return ErrUnknownKey
-	}
+func (n badverifier) Verify(data, sig []byte) error {
 
 	if len(data) != len(sig) {
 		return errLength
@@ -123,6 +146,14 @@ func (n badverifier) Verify(keyID string, data, sig []byte) error {
 	}
 
 	return nil
+}
+
+func (n badverifier) KeyID() (string, error) {
+	return "bad", nil
+}
+
+func (n badverifier) Public() crypto.PublicKey {
+	return "bad-public"
 }
 
 func TestNoSigners(t *testing.T) {
@@ -159,7 +190,9 @@ func TestNilSign(t *testing.T) {
 	}
 
 	var ns nilsigner
-	signer, _ := NewEnvelopeSigner(ns)
+	signer, err := NewEnvelopeSigner(ns)
+	assert.Nil(t, err, "unexpected error")
+
 	got, err := signer.SignPayload(payloadType, []byte(payload))
 	assert.Nil(t, err, "sign failed")
 	assert.Equal(t, &want, got, "bad signature")
@@ -167,7 +200,9 @@ func TestNilSign(t *testing.T) {
 
 func TestSignError(t *testing.T) {
 	var es errsigner
-	signer, _ := NewEnvelopeSigner(es)
+	signer, err := NewEnvelopeSigner(es)
+	assert.Nil(t, err, "unexpected error")
+
 	got, err := signer.SignPayload("t", []byte("d"))
 	assert.Nil(t, got, "expected nil")
 	assert.NotNil(t, err, "error expected")
@@ -211,12 +246,12 @@ type EcdsaSigner struct {
 	verified bool
 }
 
-func (es *EcdsaSigner) Sign(data []byte) ([]byte, string, error) {
+func (es *EcdsaSigner) Sign(data []byte) ([]byte, error) {
 	// Data is complete message, hash it and sign the digest
 	digest := sha256.Sum256(data)
 	r, s, err := rfc6979.SignECDSA(es.key, digest[:], sha256.New)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
 	rb := r.Bytes()
@@ -224,14 +259,10 @@ func (es *EcdsaSigner) Sign(data []byte) ([]byte, string, error) {
 	es.rLen = len(rb)
 	rawSig := append(rb, sb...)
 
-	return rawSig, es.keyID, nil
+	return rawSig, nil
 }
 
-func (es *EcdsaSigner) Verify(keyID string, data, sig []byte) error {
-	if keyID != es.keyID {
-		return ErrUnknownKey
-	}
-
+func (es *EcdsaSigner) Verify(data, sig []byte) error {
 	var r big.Int
 	var s big.Int
 	digest := sha256.Sum256(data)
@@ -248,6 +279,14 @@ func (es *EcdsaSigner) Verify(keyID string, data, sig []byte) error {
 		return nil
 	}
 	return errVerify
+}
+
+func (es *EcdsaSigner) KeyID() (string, error) {
+	return es.keyID, nil
+}
+
+func (es *EcdsaSigner) Public() crypto.PublicKey {
+	return es.Public
 }
 
 // Test against the example in the protocol specification:
@@ -271,15 +310,19 @@ func TestEcdsaSign(t *testing.T) {
 		},
 	}
 
-	signer, _ := NewEnvelopeSigner(ecdsa)
+	signer, err := NewEnvelopeSigner(ecdsa)
+	assert.Nil(t, err, "unexpected error")
+
 	env, err := signer.SignPayload(payloadType, []byte(payload))
 	assert.Nil(t, err, "unexpected error")
 	assert.Equal(t, &want, env, "Wrong envelope generated")
 
 	// Now verify
-	err = signer.Verify(env)
+	acceptedKeys, err := signer.Verify(env)
 	assert.Nil(t, err, "unexpected error")
 	assert.True(t, ecdsa.verified, "verify was not called")
+	assert.Len(t, acceptedKeys, 1, "unexpected keys")
+	assert.Equal(t, acceptedKeys[0].KeyID, keyID, "unexpected keyid")
 }
 
 func TestB64Decode(t *testing.T) {
@@ -320,12 +363,16 @@ func TestVerifyOneProvider(t *testing.T) {
 	var payload = "hello world"
 
 	var ns nilsigner
-	signer, _ := NewEnvelopeSigner(ns)
+	signer, err := NewEnvelopeSigner(ns)
+	assert.Nil(t, err, "unexpected error")
+
 	env, err := signer.SignPayload(payloadType, []byte(payload))
 	assert.Nil(t, err, "sign failed")
 
-	err = signer.Verify(env)
+	acceptedKeys, err := signer.Verify(env)
 	assert.Nil(t, err, "unexpected error")
+	assert.Len(t, acceptedKeys, 1, "unexpected keys")
+	assert.Equal(t, acceptedKeys[0].KeyID, "nil", "unexpected keyid")
 }
 
 func TestVerifyMultipleProvider(t *testing.T) {
@@ -334,12 +381,39 @@ func TestVerifyMultipleProvider(t *testing.T) {
 
 	var ns nilsigner
 	var null nullsigner
-	signer, _ := NewEnvelopeSigner(ns, null)
+	signer, err := NewEnvelopeSigner(ns, null)
+	assert.Nil(t, err, "unexpected error")
+
 	env, err := signer.SignPayload(payloadType, []byte(payload))
 	assert.Nil(t, err, "sign failed")
 
-	err = signer.Verify(env)
+	acceptedKeys, err := signer.Verify(env)
 	assert.Nil(t, err, "unexpected error")
+	assert.Len(t, acceptedKeys, 2, "unexpected keys")
+}
+
+func TestVerifyMultipleProviderThreshold(t *testing.T) {
+	var payloadType = "http://example.com/HelloWorld"
+	var payload = "hello world"
+
+	var ns nilsigner
+	var null nullsigner
+	signer, err := NewMultiEnvelopeSigner(2, ns, null)
+	env, err := signer.SignPayload(payloadType, []byte(payload))
+	assert.Nil(t, err, "sign failed")
+
+	acceptedKeys, err := signer.Verify(env)
+	assert.Nil(t, err, "unexpected error")
+	assert.Len(t, acceptedKeys, 2, "unexpected keys")
+}
+
+func TestVerifyMultipleProviderThresholdErr(t *testing.T) {
+	var ns nilsigner
+	var null nullsigner
+	_, err := NewMultiEnvelopeSigner(3, ns, null)
+	assert.Equal(t, errThreshold, err, "wrong error")
+	_, err = NewMultiEnvelopeSigner(0, ns, null)
+	assert.Equal(t, errThreshold, err, "wrong error")
 }
 
 func TestVerifyErr(t *testing.T) {
@@ -347,11 +421,13 @@ func TestVerifyErr(t *testing.T) {
 	var payload = "hello world"
 
 	var errv errverifier
-	signer, _ := NewEnvelopeSigner(errv)
+	signer, err := NewEnvelopeSigner(errv)
+	assert.Nil(t, err, "unexpected error")
+
 	env, err := signer.SignPayload(payloadType, []byte(payload))
 	assert.Nil(t, err, "sign failed")
 
-	err = signer.Verify(env)
+	_, err = signer.Verify(env)
 	assert.Equal(t, errVerify, err, "wrong error")
 }
 
@@ -360,26 +436,31 @@ func TestBadVerifier(t *testing.T) {
 	var payload = "hello world"
 
 	var badv badverifier
-	signer, _ := NewEnvelopeSigner(badv)
+	signer, err := NewEnvelopeSigner(badv)
+	assert.Nil(t, err, "unexpected error")
+
 	env, err := signer.SignPayload(payloadType, []byte(payload))
 	assert.Nil(t, err, "sign failed")
 
-	err = signer.Verify(env)
+	_, err = signer.Verify(env)
 	assert.NotNil(t, err, "expected error")
 }
 
 func TestVerifyNoSig(t *testing.T) {
 	var badv badverifier
-	signer, _ := NewEnvelopeSigner(badv)
+	signer, err := NewEnvelopeSigner(badv)
+	assert.Nil(t, err, "unexpected error")
+
 	env := &Envelope{}
 
-	err := signer.Verify(env)
+	_, err = signer.Verify(env)
 	assert.Equal(t, ErrNoSignature, err, "wrong error")
 }
 
 func TestVerifyBadBase64(t *testing.T) {
 	var badv badverifier
-	signer, _ := NewEnvelopeSigner(badv)
+	signer, err := NewEnvelopeSigner(badv)
+	assert.Nil(t, err, "unexpected error")
 
 	t.Run("Payload", func(t *testing.T) {
 		env := &Envelope{
@@ -389,7 +470,7 @@ func TestVerifyBadBase64(t *testing.T) {
 			},
 		}
 
-		err := signer.Verify(env)
+		_, err := signer.Verify(env)
 		assert.IsType(t, base64.CorruptInputError(0), err, "wrong error")
 	})
 
@@ -403,7 +484,7 @@ func TestVerifyBadBase64(t *testing.T) {
 			},
 		}
 
-		err := signer.Verify(env)
+		_, err := signer.Verify(env)
 		assert.IsType(t, base64.CorruptInputError(0), err, "wrong error")
 	})
 }
@@ -413,7 +494,9 @@ func TestVerifyNoMatch(t *testing.T) {
 
 	var ns nilsigner
 	var null nullsigner
-	signer, _ := NewEnvelopeSigner(ns, null)
+	signer, err := NewEnvelopeSigner(ns, null)
+	assert.Nil(t, err, "unexpected error")
+
 	env := &Envelope{
 		PayloadType: payloadType,
 		Payload:     "cGF5bG9hZAo=",
@@ -425,7 +508,7 @@ func TestVerifyNoMatch(t *testing.T) {
 		},
 	}
 
-	err := signer.Verify(env)
+	_, err = signer.Verify(env)
 	assert.NotNil(t, err, "expected error")
 }
 
@@ -435,20 +518,25 @@ type interceptSigner struct {
 	verifyCalled bool
 }
 
-func (i *interceptSigner) Sign(data []byte) ([]byte, string, error) {
-	return data, i.keyID, nil
+func (i *interceptSigner) Sign(data []byte) ([]byte, error) {
+	return data, nil
 }
 
-func (i *interceptSigner) Verify(keyID string, data, sig []byte) error {
+func (i *interceptSigner) Verify(data, sig []byte) error {
 	i.verifyCalled = true
-	if keyID != i.keyID {
-		return ErrUnknownKey
-	}
 
 	if i.verifyRes {
 		return nil
 	}
 	return errVerify
+}
+
+func (i *interceptSigner) KeyID() (string, error) {
+	return i.keyID, nil
+}
+
+func (i *interceptSigner) Public() crypto.PublicKey {
+	return "intercept-public"
 }
 
 func TestVerifyOneFail(t *testing.T) {
@@ -463,12 +551,16 @@ func TestVerifyOneFail(t *testing.T) {
 		keyID:     "i2",
 		verifyRes: false,
 	}
-	signer, _ := NewEnvelopeSigner(s1, s2)
+	signer, err := NewEnvelopeSigner(s1, s2)
+	assert.Nil(t, err, "unexpected error")
+
 	env, err := signer.SignPayload(payloadType, []byte(payload))
 	assert.Nil(t, err, "sign failed")
 
-	err = signer.Verify(env)
-	assert.NotNil(t, err, "expected error")
+	acceptedKeys, err := signer.Verify(env)
+	assert.Nil(t, err, "expected error")
 	assert.True(t, s1.verifyCalled, "verify not called")
 	assert.True(t, s2.verifyCalled, "verify not called")
+	assert.Len(t, acceptedKeys, 1, "unexpected keys")
+	assert.Equal(t, acceptedKeys[0].KeyID, "i1", "unexpected keyid")
 }

--- a/dsse/sign_test.go
+++ b/dsse/sign_test.go
@@ -108,7 +108,7 @@ func (n errsigner) Public() crypto.PublicKey {
 
 type errverifier int
 
-var errVerify = fmt.Errorf("Accepted signitures do not match threshold, Found: 0, Expected 1")
+var errVerify = fmt.Errorf("Accepted signatures do not match threshold, Found: 0, Expected 1")
 var errThreshold = fmt.Errorf("Invalid threshold")
 
 func (n errverifier) Sign(data []byte) ([]byte, error) {

--- a/dsse/verify.go
+++ b/dsse/verify.go
@@ -10,7 +10,7 @@ import (
 Verifier verifies a complete message against a signature and key.
 If the message was hashed prior to signature generation, the verifier
 must perform the same steps.
-If Keyd returns successfully only signiture matching keyid will be verfied.
+If KeyID returns successfully, only signature matching the key ID will be verified.
 */
 type Verifier interface {
 	Verify(data, sig []byte) error

--- a/dsse/verify.go
+++ b/dsse/verify.go
@@ -1,70 +1,103 @@
-/*
-Package dsse implements the Dead Simple Signing Envelope (DSSE)
-https://github.com/secure-systems-lab/dsse
-*/
 package dsse
+
+import (
+	"crypto"
+	"errors"
+	"fmt"
+)
 
 /*
 Verifier verifies a complete message against a signature and key.
 If the message was hashed prior to signature generation, the verifier
 must perform the same steps.
-If the key is not recognized ErrUnknownKey shall be returned.
+If Keyd returns successfully only signiture matching keyid will be verfied.
 */
 type Verifier interface {
-	Verify(keyID string, data, sig []byte) error
+	Verify(data, sig []byte) error
+	KeyID() (string, error)
+	Public() crypto.PublicKey
 }
 
-type EnvelopeVerifier struct {
+type envelopeMultiVerifier struct {
 	providers []Verifier
+	threshold int
 }
 
-func (ev *EnvelopeVerifier) Verify(e *Envelope) error {
+type AccesptedKey struct {
+	Public crypto.PublicKey
+	KeyID  string
+	Sig    Signature
+}
+
+func (ev *envelopeMultiVerifier) Verify(e *Envelope) ([]AccesptedKey, error) {
 	if len(e.Signatures) == 0 {
-		return ErrNoSignature
+		return nil, ErrNoSignature
 	}
 
 	// Decode payload (i.e serialized body)
 	body, err := b64Decode(e.Payload)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	// Generate PAE(payloadtype, serialized body)
 	paeEnc := PAE(e.PayloadType, string(body))
 
-	// If *any* signature is found to be incorrect, the entire verification
-	// step fails even if *some* signatures are correct.
-	verified := false
+	// If *any* signature is found to be incorrect, it is skipped
+	var accepted_keys []AccesptedKey
 	for _, s := range e.Signatures {
 		sig, err := b64Decode(s.Sig)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
-		// Loop over the providers. If a provider recognizes the key, we exit
+		// Loop over the providers.
+		// If provider and signiture include keyID's but do not match skip.
+		// If a provider recognizes the key, we exit
 		// the loop and use the result.
 		for _, v := range ev.providers {
-			err := v.Verify(s.KeyID, paeEnc, sig)
+			keyID, err := v.KeyID()
+			if s.KeyID != "" && keyID != "" && err == nil && s.KeyID != keyID {
+				continue
+			}
 			if err != nil {
-				if err == ErrUnknownKey {
-					continue
-				}
-				return err
+				keyID = ""
 			}
 
-			verified = true
+			err = v.Verify(paeEnc, sig)
+			if err != nil {
+				continue
+			}
+
+			acceptedKey := AccesptedKey{
+				Public: v.Public(),
+				KeyID:  keyID,
+				Sig:    s,
+			}
+
+			accepted_keys = append(accepted_keys, acceptedKey)
 			break
 		}
 	}
-	if !verified {
-		return ErrUnknownKey
+	if len(accepted_keys) < ev.threshold {
+		return accepted_keys, errors.New(fmt.Sprintf("Accepted signitures do not match threshold, Found: %d, Expected %d", len(accepted_keys), ev.threshold))
 	}
 
-	return nil
+	return accepted_keys, nil
 }
 
-func NewEnvelopeVerifier(p ...Verifier) EnvelopeVerifier {
-	ev := EnvelopeVerifier{
-		providers: p,
+func NewEnvelopeVerifier(v ...Verifier) (*envelopeMultiVerifier, error) {
+	return NewMultiEnvelopeVerifier(1, v...)
+}
+
+func NewMultiEnvelopeVerifier(threshold int, p ...Verifier) (*envelopeMultiVerifier, error) {
+
+	if threshold <= 0 || threshold > len(p) {
+		return nil, errors.New("Invalid threshold")
 	}
-	return ev
+
+	ev := envelopeMultiVerifier{
+		providers: p,
+		threshold: threshold,
+	}
+	return &ev, nil
 }

--- a/dsse/verify.go
+++ b/dsse/verify.go
@@ -52,7 +52,7 @@ func (ev *envelopeVerifier) Verify(e *Envelope) ([]AcceptedKeys, error) {
 		}
 
 		// Loop over the providers.
-		// If provider and signiture include keyID's but do not match skip.
+		// If provider and signature include key IDs but do not match skip.
 		// If a provider recognizes the key, we exit
 		// the loop and use the result.
 		for _, v := range ev.providers {

--- a/dsse/verify.go
+++ b/dsse/verify.go
@@ -18,7 +18,7 @@ type Verifier interface {
 	Public() crypto.PublicKey
 }
 
-type envelopeMultiVerifier struct {
+type envelopeVerifier struct {
 	providers []Verifier
 	threshold int
 }
@@ -29,7 +29,7 @@ type AccesptedKey struct {
 	Sig    Signature
 }
 
-func (ev *envelopeMultiVerifier) Verify(e *Envelope) ([]AccesptedKey, error) {
+func (ev *envelopeVerifier) Verify(e *Envelope) ([]AccesptedKey, error) {
 	if len(e.Signatures) == 0 {
 		return nil, ErrNoSignature
 	}
@@ -85,17 +85,17 @@ func (ev *envelopeMultiVerifier) Verify(e *Envelope) ([]AccesptedKey, error) {
 	return accepted_keys, nil
 }
 
-func NewEnvelopeVerifier(v ...Verifier) (*envelopeMultiVerifier, error) {
+func NewEnvelopeVerifier(v ...Verifier) (*envelopeVerifier, error) {
 	return NewMultiEnvelopeVerifier(1, v...)
 }
 
-func NewMultiEnvelopeVerifier(threshold int, p ...Verifier) (*envelopeMultiVerifier, error) {
+func NewMultiEnvelopeVerifier(threshold int, p ...Verifier) (*envelopeVerifier, error) {
 
 	if threshold <= 0 || threshold > len(p) {
 		return nil, errors.New("Invalid threshold")
 	}
 
-	ev := envelopeMultiVerifier{
+	ev := envelopeVerifier{
 		providers: p,
 		threshold: threshold,
 	}

--- a/dsse/verify.go
+++ b/dsse/verify.go
@@ -23,13 +23,13 @@ type envelopeVerifier struct {
 	threshold int
 }
 
-type AccesptedKey struct {
+type AcceptedKeys struct {
 	Public crypto.PublicKey
 	KeyID  string
 	Sig    Signature
 }
 
-func (ev *envelopeVerifier) Verify(e *Envelope) ([]AccesptedKey, error) {
+func (ev *envelopeVerifier) Verify(e *Envelope) ([]AcceptedKeys, error) {
 	if len(e.Signatures) == 0 {
 		return nil, ErrNoSignature
 	}
@@ -43,7 +43,7 @@ func (ev *envelopeVerifier) Verify(e *Envelope) ([]AccesptedKey, error) {
 	paeEnc := PAE(e.PayloadType, string(body))
 
 	// If *any* signature is found to be incorrect, it is skipped
-	var accepted_keys []AccesptedKey
+	var accepted_keys []AcceptedKeys
 	for _, s := range e.Signatures {
 		sig, err := b64Decode(s.Sig)
 		if err != nil {
@@ -68,7 +68,7 @@ func (ev *envelopeVerifier) Verify(e *Envelope) ([]AccesptedKey, error) {
 				continue
 			}
 
-			acceptedKey := AccesptedKey{
+			acceptedKey := AcceptedKeys{
 				Public: v.Public(),
 				KeyID:  keyID,
 				Sig:    s,

--- a/dsse/verify.go
+++ b/dsse/verify.go
@@ -84,7 +84,7 @@ func (ev *envelopeVerifier) Verify(e *Envelope) ([]AcceptedKey, error) {
 				KeyID:  keyID,
 				Sig:    s,
 			}
-			unverified_providers = RemoveIndex(providers, i)
+			unverified_providers = removeIndex(providers, i)
 
 			// See https://github.com/in-toto/in-toto/pull/251
 			if _, ok := usedKeyids[keyID]; ok {

--- a/dsse/verify.go
+++ b/dsse/verify.go
@@ -137,6 +137,6 @@ func SHA256KeyID(pub crypto.PublicKey) (string, error) {
 	return fingerprint, nil
 }
 
-func RemoveIndex(v []Verifier, index int) []Verifier {
+func removeIndex(v []Verifier, index int) []Verifier {
 	return append(v[:index], v[index+1:]...)
 }

--- a/dsse/verify.go
+++ b/dsse/verify.go
@@ -101,7 +101,7 @@ func (ev *envelopeVerifier) Verify(e *Envelope) ([]AcceptedKey, error) {
 	}
 
 	if len(usedKeyids) < ev.threshold {
-		return acceptedKeys, errors.New(fmt.Sprintf("Accepted signitures do not match threshold, Found: %d, Expected %d", len(acceptedKeys), ev.threshold))
+		return acceptedKeys, errors.New(fmt.Sprintf("Accepted signatures do not match threshold, Found: %d, Expected %d", len(acceptedKeys), ev.threshold))
 	}
 
 	return acceptedKeys, nil

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,12 @@ go 1.17
 require (
 	github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871
 )
 
-require golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,4 @@ require (
 	github.com/stretchr/testify v1.7.0
 )
 
-require (
-	github.com/davecgh/go-spew v1.1.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
-)
+require golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,17 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 h1:/pEO3GD/ABYAjuakUS6xSEmmlyVS4kxBNkeA9tLJiTI=
+golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=


### PR DESCRIPTION
Hi.
I have created a PR that includes a small refactor to the interfaces and the internal code.
1) Added support for multiple signature validation (Signature support was already implemented)
2) Signer/Verifier interfaces change suggestion to support both public,keyid methods.
3) Signer/Verifier interface change suggestion - remove keyid from the `sign`, `verify` methods..
4) Add/Fix tests accordingly 

After implementing the multi signature validation struct it seemed that maybe i can clean it up a bit by unified the multi signature flow and the current single signature validation flow.


