### PR TITLE
Ensure that EnvelopeVerifier.Verify does not panic on nil envelope

### DIFF
--- a/dsse/verify.go
+++ b/dsse/verify.go
@@ -32,6 +32,10 @@ type AcceptedKey struct {
 }
 
 func (ev *EnvelopeVerifier) Verify(e *Envelope) ([]AcceptedKey, error) {
+	if e == nil {
+		return nil, errors.New("cannot verify a nil envelope")
+	}
+
 	if len(e.Signatures) == 0 {
 		return nil, ErrNoSignature
 	}

--- a/dsse/verify_test.go
+++ b/dsse/verify_test.go
@@ -8,6 +8,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestEnvelopeVerifier_Verify_HandlesNil(t *testing.T) {
+	verifier, err := NewEnvelopeVerifier(&mockVerifier{})
+	assert.NoError(t, err)
+
+	acceptedKeys, err := verifier.Verify(nil)
+	assert.Empty(t, acceptedKeys)
+	assert.EqualError(t, err, "cannot verify a nil envelope")
+}
+
 type mockVerifier struct {
 	returnErr error
 }


### PR DESCRIPTION
Fixes #13