### PR TITLE
feat: add dependabot for monitoring Go and GitHub Actions dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  # Monitor Go dependencies
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "10:00"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    open-pull-requests-limit: 10
+  # Monitor Github Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "10:00"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
The following PR adds Dependabot to the [go-securesystemslib](https://github.com/secure-systems-lab/go-securesystemslib) project for monitoring its Go and GitHub Actions dependencies.

It has been motivated by the recent vulnerability found in `gopkg.in/yaml.v3 v3.0.0` which got flagged in go-tuf. Upon further debugging it was found to be a transitive dependency from `github.com/stretchr/testify`.

Signed-off-by: Radoslav Dimitrov <dimitrovr@vmware.com>