### PR TITLE
Add staticcheck-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,3 +26,12 @@ jobs:
       run: |
         GO111MODULE=off go get github.com/mattn/goveralls
         $(go env GOPATH)/bin/goveralls -coverprofile=profile.cov -service=github
+  staticcheck:
+    name: "Run staticcheck"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - uses: dominikh/staticcheck-action@v1.2.0
+      with:
+        version: "2022.1"

--- a/dsse/sign_test.go
+++ b/dsse/sign_test.go
@@ -114,8 +114,8 @@ func (n errsigner) Public() crypto.PublicKey {
 
 type errverifier int
 
-var errVerify = fmt.Errorf("Accepted signatures do not match threshold, Found: 0, Expected 1")
-var errThreshold = fmt.Errorf("Invalid threshold")
+var errVerify = fmt.Errorf("accepted signatures do not match threshold, Found: 0, Expected 1")
+var errThreshold = fmt.Errorf("invalid threshold")
 
 func (n errverifier) Sign(data []byte) ([]byte, error) {
 	return data, nil
@@ -417,6 +417,7 @@ func TestVerifyMultipleProviderThreshold(t *testing.T) {
 	var ns nilsigner
 	var null nullsigner
 	signer, err := NewMultiEnvelopeSigner(2, ns, null)
+	assert.Nil(t, err)
 	env, err := signer.SignPayload(payloadType, []byte(payload))
 	assert.Nil(t, err, "sign failed")
 

--- a/dsse/verify.go
+++ b/dsse/verify.go
@@ -104,11 +104,11 @@ func (ev *EnvelopeVerifier) Verify(e *Envelope) ([]AcceptedKey, error) {
 
 	// Sanity if with some reflect magic this happens.
 	if ev.threshold <= 0 || ev.threshold > len(ev.providers) {
-		return nil, errors.New("Invalid threshold")
+		return nil, errors.New("invalid threshold")
 	}
 
 	if len(usedKeyids) < ev.threshold {
-		return acceptedKeys, errors.New(fmt.Sprintf("Accepted signatures do not match threshold, Found: %d, Expected %d", len(acceptedKeys), ev.threshold))
+		return acceptedKeys, fmt.Errorf("accepted signatures do not match threshold, Found: %d, Expected %d", len(acceptedKeys), ev.threshold)
 	}
 
 	return acceptedKeys, nil
@@ -121,7 +121,7 @@ func NewEnvelopeVerifier(v ...Verifier) (*EnvelopeVerifier, error) {
 func NewMultiEnvelopeVerifier(threshold int, p ...Verifier) (*EnvelopeVerifier, error) {
 
 	if threshold <= 0 || threshold > len(p) {
-		return nil, errors.New("Invalid threshold")
+		return nil, errors.New("invalid threshold")
 	}
 
 	ev := EnvelopeVerifier{


### PR DESCRIPTION
Introduce [staticcheck-action](https://github.com/dominikh/staticcheck-action) and correct the following errors:
```
Error: dsse/sign_test.go:117:17: error strings should not be capitalized (ST1005)
Error: dsse/sign_test.go:118:20: error strings should not be capitalized (ST1005)
Error: dsse/sign_test.go:419:2: this value of err is never used (SA4006)
Error: dsse/verify.go:107:15: error strings should not be capitalized (ST1005)
Error: dsse/verify.go:111:24: should use fmt.Errorf(...) instead of errors.New(fmt.Sprintf(...)) (S1028)
Error: dsse/verify.go:124:15: error strings should not be capitalized (ST1005)
Error: Process completed with exit code 1.
```

close https://github.com/secure-systems-lab/go-securesystemslib/issues/15