### PR TITLE
Added ctx parameter to Sign and Verify interfaces to allow context pa…

### DIFF
--- a/dsse/sign.go
+++ b/dsse/sign.go
@@ -5,6 +5,7 @@ https://github.com/secure-systems-lab/dsse
 package dsse
 
 import (
+	"context"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -77,7 +78,7 @@ using the current algorithm, and the key used (if applicable).
 For an example see EcdsaSigner in sign_test.go.
 */
 type Signer interface {
-	Sign(data []byte) ([]byte, error)
+	Sign(ctx context.Context, data []byte) ([]byte, error)
 	KeyID() (string, error)
 }
 
@@ -143,7 +144,7 @@ Returned is an envelope as defined here:
 https://github.com/secure-systems-lab/dsse/blob/master/envelope.md
 One signature will be added for each Signer in the EnvelopeSigner.
 */
-func (es *EnvelopeSigner) SignPayload(payloadType string, body []byte) (*Envelope, error) {
+func (es *EnvelopeSigner) SignPayload(ctx context.Context, payloadType string, body []byte) (*Envelope, error) {
 	var e = Envelope{
 		Payload:     base64.StdEncoding.EncodeToString(body),
 		PayloadType: payloadType,
@@ -152,7 +153,7 @@ func (es *EnvelopeSigner) SignPayload(payloadType string, body []byte) (*Envelop
 	paeEnc := PAE(payloadType, body)
 
 	for _, signer := range es.providers {
-		sig, err := signer.Sign(paeEnc)
+		sig, err := signer.Sign(ctx, paeEnc)
 		if err != nil {
 			return nil, err
 		}
@@ -176,8 +177,8 @@ Any domain specific validation such as parsing the decoded body and
 validating the payload type is left out to the caller.
 Verify returns a list of accepted keys each including a keyid, public and signiture of the accepted provider keys.
 */
-func (es *EnvelopeSigner) Verify(e *Envelope) ([]AcceptedKey, error) {
-	return es.ev.Verify(e)
+func (es *EnvelopeSigner) Verify(ctx context.Context, e *Envelope) ([]AcceptedKey, error) {
+	return es.ev.Verify(ctx, e)
 }
 
 /*

--- a/dsse/verify.go
+++ b/dsse/verify.go
@@ -1,6 +1,7 @@
 package dsse
 
 import (
+	"context"
 	"crypto"
 	"errors"
 	"fmt"
@@ -15,7 +16,7 @@ must perform the same steps.
 If KeyID returns successfully, only signature matching the key ID will be verified.
 */
 type Verifier interface {
-	Verify(data, sig []byte) error
+	Verify(ctx context.Context, data, sig []byte) error
 	KeyID() (string, error)
 	Public() crypto.PublicKey
 }
@@ -31,7 +32,7 @@ type AcceptedKey struct {
 	Sig    Signature
 }
 
-func (ev *EnvelopeVerifier) Verify(e *Envelope) ([]AcceptedKey, error) {
+func (ev *EnvelopeVerifier) Verify(ctx context.Context, e *Envelope) ([]AcceptedKey, error) {
 	if e == nil {
 		return nil, errors.New("cannot verify a nil envelope")
 	}
@@ -78,7 +79,7 @@ func (ev *EnvelopeVerifier) Verify(e *Envelope) ([]AcceptedKey, error) {
 				continue
 			}
 
-			err = v.Verify(paeEnc, sig)
+			err = v.Verify(ctx, paeEnc, sig)
 			if err != nil {
 				continue
 			}

--- a/dsse/verify_test.go
+++ b/dsse/verify_test.go
@@ -1,6 +1,7 @@
 package dsse
 
 import (
+	"context"
 	"crypto"
 	"errors"
 	"testing"
@@ -12,7 +13,7 @@ func TestEnvelopeVerifier_Verify_HandlesNil(t *testing.T) {
 	verifier, err := NewEnvelopeVerifier(&mockVerifier{})
 	assert.NoError(t, err)
 
-	acceptedKeys, err := verifier.Verify(nil)
+	acceptedKeys, err := verifier.Verify(context.TODO(), nil)
 	assert.Empty(t, acceptedKeys)
 	assert.EqualError(t, err, "cannot verify a nil envelope")
 }
@@ -21,7 +22,7 @@ type mockVerifier struct {
 	returnErr error
 }
 
-func (m *mockVerifier) Verify(data, sig []byte) error {
+func (m *mockVerifier) Verify(ctx context.Context, data, sig []byte) error {
 	if m.returnErr != nil {
 		return m.returnErr
 	}
@@ -55,7 +56,7 @@ func TestVerify(t *testing.T) {
 
 	ev, err := NewEnvelopeVerifier(&mockVerifier{})
 	assert.Nil(t, err, "unexpected error")
-	acceptedKeys, err := ev.Verify(&e)
+	acceptedKeys, err := ev.Verify(context.TODO(), &e)
 
 	// Now verify
 	assert.Nil(t, err, "unexpected error")
@@ -65,7 +66,7 @@ func TestVerify(t *testing.T) {
 	// Now try an error
 	ev, err = NewEnvelopeVerifier(&mockVerifier{returnErr: errors.New("uh oh")})
 	assert.Nil(t, err, "unexpected error")
-	_, err = ev.Verify(&e)
+	_, err = ev.Verify(context.TODO(), &e)
 
 	// Now verify
 	assert.Error(t, err)


### PR DESCRIPTION
…ssing in the case of remote calls to sign/verify an envelope (i.e. a KMS call)