### PR TITLE
Drop support for 1.16.x, add support for latest versions of Go

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: [1.17.x, 1.18.x, 1.19.x, 1.20.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Looks like we've missed updating Go versions in our CI, so fast tracking for now all the way through 1.20.x. I imagine we can drop 1.17.x and possibly 1.18.x in the not too distant future.