### PR TITLE
feat: move the encrypted package to go-sslib

### DIFF
--- a/encrypted/encrypted.go
+++ b/encrypted/encrypted.go
@@ -1,0 +1,290 @@
+// Package encrypted provides a simple, secure system for encrypting data
+// symmetrically with a passphrase.
+//
+// It uses scrypt derive a key from the passphrase and the NaCl secret box
+// cipher for authenticated encryption.
+package encrypted
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"golang.org/x/crypto/nacl/secretbox"
+	"golang.org/x/crypto/scrypt"
+)
+
+const saltSize = 32
+
+const (
+	boxKeySize   = 32
+	boxNonceSize = 24
+)
+
+// KDFParameterStrength defines the KDF parameter strength level to be used for
+// encryption key derivation.
+type KDFParameterStrength uint8
+
+const (
+	// Legacy defines legacy scrypt parameters (N:2^15, r:8, p:1)
+	Legacy KDFParameterStrength = iota + 1
+	// Standard defines standard scrypt parameters which is focusing 100ms of computation (N:2^16, r:8, p:1)
+	Standard
+	// OWASP defines OWASP recommended scrypt parameters (N:2^17, r:8, p:1)
+	OWASP
+)
+
+var (
+	// legacyParams represents old scrypt derivation parameters for backward
+	// compatibility.
+	legacyParams = scryptParams{
+		N: 32768, // 2^15
+		R: 8,
+		P: 1,
+	}
+
+	// standardParams defines scrypt parameters based on the scrypt creator
+	// recommendation to limit key derivation in time boxed to 100ms.
+	standardParams = scryptParams{
+		N: 65536, // 2^16
+		R: 8,
+		P: 1,
+	}
+
+	// owaspParams defines scrypt parameters recommended by OWASP
+	owaspParams = scryptParams{
+		N: 131072, // 2^17
+		R: 8,
+		P: 1,
+	}
+
+	// defaultParams defines scrypt parameters which will be used to generate a
+	// new key.
+	defaultParams = standardParams
+)
+
+const (
+	nameScrypt    = "scrypt"
+	nameSecretBox = "nacl/secretbox"
+)
+
+type data struct {
+	KDF        scryptKDF       `json:"kdf"`
+	Cipher     secretBoxCipher `json:"cipher"`
+	Ciphertext []byte          `json:"ciphertext"`
+}
+
+type scryptParams struct {
+	N int `json:"N"`
+	R int `json:"r"`
+	P int `json:"p"`
+}
+
+func (sp *scryptParams) Equal(in *scryptParams) bool {
+	return in != nil && sp.N == in.N && sp.P == in.P && sp.R == in.R
+}
+
+func newScryptKDF(level KDFParameterStrength) (scryptKDF, error) {
+	salt := make([]byte, saltSize)
+	if err := fillRandom(salt); err != nil {
+		return scryptKDF{}, fmt.Errorf("unable to generate a random salt: %w", err)
+	}
+
+	var params scryptParams
+	switch level {
+	case Legacy:
+		params = legacyParams
+	case Standard:
+		params = standardParams
+	case OWASP:
+		params = owaspParams
+	default:
+		// Fallback to default parameters
+		params = defaultParams
+	}
+
+	return scryptKDF{
+		Name:   nameScrypt,
+		Params: params,
+		Salt:   salt,
+	}, nil
+}
+
+type scryptKDF struct {
+	Name   string       `json:"name"`
+	Params scryptParams `json:"params"`
+	Salt   []byte       `json:"salt"`
+}
+
+func (s *scryptKDF) Key(passphrase []byte) ([]byte, error) {
+	return scrypt.Key(passphrase, s.Salt, s.Params.N, s.Params.R, s.Params.P, boxKeySize)
+}
+
+// CheckParams checks that the encoded KDF parameters are what we expect them to
+// be. If we do not do this, an attacker could cause a DoS by tampering with
+// them.
+func (s *scryptKDF) CheckParams() error {
+	switch {
+	case legacyParams.Equal(&s.Params):
+	case standardParams.Equal(&s.Params):
+	case owaspParams.Equal(&s.Params):
+	default:
+		return errors.New("unsupported scrypt parameters")
+	}
+
+	return nil
+}
+
+func newSecretBoxCipher() (secretBoxCipher, error) {
+	nonce := make([]byte, boxNonceSize)
+	if err := fillRandom(nonce); err != nil {
+		return secretBoxCipher{}, err
+	}
+	return secretBoxCipher{
+		Name:  nameSecretBox,
+		Nonce: nonce,
+	}, nil
+}
+
+type secretBoxCipher struct {
+	Name  string `json:"name"`
+	Nonce []byte `json:"nonce"`
+
+	encrypted bool
+}
+
+func (s *secretBoxCipher) Encrypt(plaintext, key []byte) []byte {
+	var keyBytes [boxKeySize]byte
+	var nonceBytes [boxNonceSize]byte
+
+	if len(key) != len(keyBytes) {
+		panic("incorrect key size")
+	}
+	if len(s.Nonce) != len(nonceBytes) {
+		panic("incorrect nonce size")
+	}
+
+	copy(keyBytes[:], key)
+	copy(nonceBytes[:], s.Nonce)
+
+	// ensure that we don't re-use nonces
+	if s.encrypted {
+		panic("Encrypt must only be called once for each cipher instance")
+	}
+	s.encrypted = true
+
+	return secretbox.Seal(nil, plaintext, &nonceBytes, &keyBytes)
+}
+
+func (s *secretBoxCipher) Decrypt(ciphertext, key []byte) ([]byte, error) {
+	var keyBytes [boxKeySize]byte
+	var nonceBytes [boxNonceSize]byte
+
+	if len(key) != len(keyBytes) {
+		panic("incorrect key size")
+	}
+	if len(s.Nonce) != len(nonceBytes) {
+		// return an error instead of panicking since the nonce is user input
+		return nil, errors.New("encrypted: incorrect nonce size")
+	}
+
+	copy(keyBytes[:], key)
+	copy(nonceBytes[:], s.Nonce)
+
+	res, ok := secretbox.Open(nil, ciphertext, &nonceBytes, &keyBytes)
+	if !ok {
+		return nil, errors.New("encrypted: decryption failed")
+	}
+	return res, nil
+}
+
+// Encrypt takes a passphrase and plaintext, and returns a JSON object
+// containing ciphertext and the details necessary to decrypt it.
+func Encrypt(plaintext, passphrase []byte) ([]byte, error) {
+	return EncryptWithCustomKDFParameters(plaintext, passphrase, Standard)
+}
+
+// EncryptWithCustomKDFParameters takes a passphrase, the plaintext and a KDF
+// parameter level (Legacy, Standard, or OWASP), and returns a JSON object
+// containing ciphertext and the details necessary to decrypt it.
+func EncryptWithCustomKDFParameters(plaintext, passphrase []byte, kdfLevel KDFParameterStrength) ([]byte, error) {
+	k, err := newScryptKDF(kdfLevel)
+	if err != nil {
+		return nil, err
+	}
+	key, err := k.Key(passphrase)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := newSecretBoxCipher()
+	if err != nil {
+		return nil, err
+	}
+
+	data := &data{
+		KDF:    k,
+		Cipher: c,
+	}
+	data.Ciphertext = c.Encrypt(plaintext, key)
+
+	return json.Marshal(data)
+}
+
+// Marshal encrypts the JSON encoding of v using passphrase.
+func Marshal(v interface{}, passphrase []byte) ([]byte, error) {
+	return MarshalWithCustomKDFParameters(v, passphrase, Standard)
+}
+
+// MarshalWithCustomKDFParameters encrypts the JSON encoding of v using passphrase.
+func MarshalWithCustomKDFParameters(v interface{}, passphrase []byte, kdfLevel KDFParameterStrength) ([]byte, error) {
+	data, err := json.MarshalIndent(v, "", "\t")
+	if err != nil {
+		return nil, err
+	}
+	return EncryptWithCustomKDFParameters(data, passphrase, kdfLevel)
+}
+
+// Decrypt takes a JSON-encoded ciphertext object encrypted using Encrypt and
+// tries to decrypt it using passphrase. If successful, it returns the
+// plaintext.
+func Decrypt(ciphertext, passphrase []byte) ([]byte, error) {
+	data := &data{}
+	if err := json.Unmarshal(ciphertext, data); err != nil {
+		return nil, err
+	}
+
+	if data.KDF.Name != nameScrypt {
+		return nil, fmt.Errorf("encrypted: unknown kdf name %q", data.KDF.Name)
+	}
+	if data.Cipher.Name != nameSecretBox {
+		return nil, fmt.Errorf("encrypted: unknown cipher name %q", data.Cipher.Name)
+	}
+	if err := data.KDF.CheckParams(); err != nil {
+		return nil, err
+	}
+
+	key, err := data.KDF.Key(passphrase)
+	if err != nil {
+		return nil, err
+	}
+
+	return data.Cipher.Decrypt(data.Ciphertext, key)
+}
+
+// Unmarshal decrypts the data using passphrase and unmarshals the resulting
+// plaintext into the value pointed to by v.
+func Unmarshal(data []byte, v interface{}, passphrase []byte) error {
+	decrypted, err := Decrypt(data, passphrase)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(decrypted, v)
+}
+
+func fillRandom(b []byte) error {
+	_, err := io.ReadFull(rand.Reader, b)
+	return err
+}

--- a/encrypted/encrypted_test.go
+++ b/encrypted/encrypted_test.go
@@ -2,10 +2,9 @@ package encrypted
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
 
-	. "gopkg.in/check.v1"
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -16,143 +15,136 @@ var (
 	}
 )
 
-// Hook up gocheck into the "go test" runner.
-func Test(t *testing.T) { TestingT(t) }
-
-type EncryptedSuite struct{}
-
-var _ = Suite(&EncryptedSuite{})
-
 var plaintext = []byte("reallyimportant")
 
-func (EncryptedSuite) TestRoundtrip(c *C) {
+func TestRoundtrip(t *testing.T) {
 	passphrase := []byte("supersecret")
 
 	enc, err := Encrypt(plaintext, passphrase)
-	c.Assert(err, IsNil)
+	assert.Nil(t, err)
 
 	// successful decrypt
 	dec, err := Decrypt(enc, passphrase)
-	c.Assert(err, IsNil)
-	c.Assert(dec, DeepEquals, plaintext)
+	assert.Nil(t, err)
+	assert.Equal(t, plaintext, dec)
 
 	// wrong passphrase
 	passphrase[0] = 0
 	dec, err = Decrypt(enc, passphrase)
-	c.Assert(err, NotNil)
-	c.Assert(dec, IsNil)
+	assert.NotNil(t, err)
+	assert.Nil(t, dec)
 }
 
-func (EncryptedSuite) TestTamperedRoundtrip(c *C) {
+func TestTamperedRoundtrip(t *testing.T) {
 	passphrase := []byte("supersecret")
 
 	enc, err := Encrypt(plaintext, passphrase)
-	c.Assert(err, IsNil)
+	assert.Nil(t, err)
 
 	data := &data{}
 	err = json.Unmarshal(enc, data)
-	c.Assert(err, IsNil)
+	assert.Nil(t, err)
 
 	data.Ciphertext[0] = ^data.Ciphertext[0]
 
 	enc, _ = json.Marshal(data)
 
 	dec, err := Decrypt(enc, passphrase)
-	c.Assert(err, NotNil)
-	c.Assert(dec, IsNil)
+	assert.NotNil(t, err)
+	assert.Nil(t, dec)
 }
 
-func (EncryptedSuite) TestDecrypt(c *C) {
+func TestDecrypt(t *testing.T) {
 	enc := []byte(`{"kdf":{"name":"scrypt","params":{"N":32768,"r":8,"p":1},"salt":"N9a7x5JFGbrtB2uBR81jPwp0eiLR4A7FV3mjVAQrg1g="},"cipher":{"name":"nacl/secretbox","nonce":"2h8HxMmgRfuYdpswZBQaU3xJ1nkA/5Ik"},"ciphertext":"SEW6sUh0jf2wfdjJGPNS9+bkk2uB+Cxamf32zR8XkQ=="}`)
 	passphrase := []byte("supersecret")
 
 	dec, err := Decrypt(enc, passphrase)
-	c.Assert(err, IsNil)
-	c.Assert(dec, DeepEquals, plaintext)
+	assert.Nil(t, err)
+	assert.Equal(t, plaintext, dec)
 }
 
-func (EncryptedSuite) TestMarshalUnmarshal(c *C) {
+func TestMarshalUnmarshal(t *testing.T) {
 	passphrase := []byte("supersecret")
 
 	wrapped, err := Marshal(plaintext, passphrase)
-	c.Assert(err, IsNil)
-	c.Assert(wrapped, NotNil)
+	assert.Nil(t, err)
+	assert.NotNil(t, wrapped)
 
 	var protected []byte
 	err = Unmarshal(wrapped, &protected, passphrase)
-	c.Assert(err, IsNil)
-	c.Assert(protected, DeepEquals, plaintext)
+	assert.Nil(t, err)
+	assert.Equal(t, plaintext, protected)
 }
 
-func (EncryptedSuite) TestInvalidKDFSettings(c *C) {
+func TestInvalidKDFSettings(t *testing.T) {
 	passphrase := []byte("supersecret")
 
 	wrapped, err := MarshalWithCustomKDFParameters(plaintext, passphrase, 0)
-	c.Assert(err, IsNil)
-	c.Assert(wrapped, NotNil)
+	assert.Nil(t, err)
+	assert.NotNil(t, wrapped)
 
 	var protected []byte
 	err = Unmarshal(wrapped, &protected, passphrase)
-	c.Assert(err, IsNil)
-	c.Assert(protected, DeepEquals, plaintext)
+	assert.Nil(t, err)
+	assert.Equal(t, plaintext, protected)
 }
 
-func (EncryptedSuite) TestLegacyKDFSettings(c *C) {
+func TestLegacyKDFSettings(t *testing.T) {
 	passphrase := []byte("supersecret")
 
 	wrapped, err := MarshalWithCustomKDFParameters(plaintext, passphrase, Legacy)
-	c.Assert(err, IsNil)
-	c.Assert(wrapped, NotNil)
+	assert.Nil(t, err)
+	assert.NotNil(t, wrapped)
 
 	var protected []byte
 	err = Unmarshal(wrapped, &protected, passphrase)
-	c.Assert(err, IsNil)
-	c.Assert(protected, DeepEquals, plaintext)
+	assert.Nil(t, err)
+	assert.Equal(t, plaintext, protected)
 }
 
-func (EncryptedSuite) TestStandardKDFSettings(c *C) {
+func TestStandardKDFSettings(t *testing.T) {
 	passphrase := []byte("supersecret")
 
 	wrapped, err := MarshalWithCustomKDFParameters(plaintext, passphrase, Standard)
-	c.Assert(err, IsNil)
-	c.Assert(wrapped, NotNil)
+	assert.Nil(t, err)
+	assert.NotNil(t, wrapped)
 
 	var protected []byte
 	err = Unmarshal(wrapped, &protected, passphrase)
-	c.Assert(err, IsNil)
-	c.Assert(protected, DeepEquals, plaintext)
+	assert.Nil(t, err)
+	assert.Equal(t, plaintext, protected)
 }
 
-func (EncryptedSuite) TestOWASPKDFSettings(c *C) {
+func TestOWASPKDFSettings(t *testing.T) {
 	passphrase := []byte("supersecret")
 
 	wrapped, err := MarshalWithCustomKDFParameters(plaintext, passphrase, OWASP)
-	c.Assert(err, IsNil)
-	c.Assert(wrapped, NotNil)
+	assert.Nil(t, err)
+	assert.NotNil(t, wrapped)
 
 	var protected []byte
 	err = Unmarshal(wrapped, &protected, passphrase)
-	c.Assert(err, IsNil)
-	c.Assert(protected, DeepEquals, plaintext)
+	assert.Nil(t, err)
+	assert.Equal(t, plaintext, protected)
 }
 
-func (EncryptedSuite) TestKDFSettingVectors(c *C) {
+func TestKDFSettingVectors(t *testing.T) {
 	passphrase := []byte("supersecret")
 
 	for _, v := range kdfVectors {
 		var protected []byte
 		err := Unmarshal(v, &protected, passphrase)
-		c.Assert(err, IsNil)
-		c.Assert(protected, DeepEquals, plaintext)
+		assert.Nil(t, err)
+		assert.Equal(t, plaintext, protected)
 	}
 }
 
-func (EncryptedSuite) TestUnsupportedKDFParameters(c *C) {
+func TestUnsupportedKDFParameters(t *testing.T) {
 	enc := []byte(`{"kdf":{"name":"scrypt","params":{"N":99,"r":99,"p":99},"salt":"cZFcQJdwPhPyhU1R4qkl0qVOIjZd4V/7LYYAavq166k="},"cipher":{"name":"nacl/secretbox","nonce":"7vhRS7j0hEPBWV05skAdgLj81AkGeE7U"},"ciphertext":"6WYU/YSXVbYzl/NzaeAzmjLyfFhOOjLc0d8/GFV0aBFdJvyCcXc="}`)
 	passphrase := []byte("supersecret")
 
 	dec, err := Decrypt(enc, passphrase)
-	c.Assert(err, NotNil)
-	c.Assert(dec, IsNil)
-	c.Assert(strings.Contains(err.Error(), "unsupported scrypt parameters"), Equals, true)
+	assert.NotNil(t, err)
+	assert.Nil(t, dec)
+	assert.ErrorContains(t, err, "unsupported scrypt parameters")
 }

--- a/encrypted/encrypted_test.go
+++ b/encrypted/encrypted_test.go
@@ -1,0 +1,158 @@
+package encrypted
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+var (
+	kdfVectors = map[KDFParameterStrength][]byte{
+		Legacy:   []byte(`{"kdf":{"name":"scrypt","params":{"N":32768,"r":8,"p":1},"salt":"WO3mVvyTwJ9vwT5/Tk5OW5WPIBUofMjcpEfrLnfY4uA="},"cipher":{"name":"nacl/secretbox","nonce":"tCy7HcTFr4uxv4Nrg/DWmncuZ148U1MX"},"ciphertext":"08n43p5G5yviPEZpO7tPPF4aZQkWiWjkv4taFdhDBA0tamKH4nw="}`),
+		Standard: []byte(`{"kdf":{"name":"scrypt","params":{"N":65536,"r":8,"p":1},"salt":"FhzPOt9/bJG4PTq6lQ6ecG6GzaOuOy/ynG5+yRiFlNs="},"cipher":{"name":"nacl/secretbox","nonce":"aw1ng1jHaDz/tQ7V2gR9O2+IGQ8xJEuE"},"ciphertext":"HycvuLZL4sYH0BrYTh4E/H20VtAW6u5zL5Pr+IBjYLYnCPzDkq8="}`),
+		OWASP:    []byte(`{"kdf":{"name":"scrypt","params":{"N":131072,"r":8,"p":1},"salt":"m38E3kouJTtiheLQN22NQ8DTito5hrjpUIskqcd375k="},"cipher":{"name":"nacl/secretbox","nonce":"Y6PM13yA+o44pE/W1ZBwczeGnTV/m9Zc"},"ciphertext":"6H8sqj1K6B6yDjtH5AQ6lbFigg/C2yDDJc4rYJ79w9aVPImFIPI="}`),
+	}
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { TestingT(t) }
+
+type EncryptedSuite struct{}
+
+var _ = Suite(&EncryptedSuite{})
+
+var plaintext = []byte("reallyimportant")
+
+func (EncryptedSuite) TestRoundtrip(c *C) {
+	passphrase := []byte("supersecret")
+
+	enc, err := Encrypt(plaintext, passphrase)
+	c.Assert(err, IsNil)
+
+	// successful decrypt
+	dec, err := Decrypt(enc, passphrase)
+	c.Assert(err, IsNil)
+	c.Assert(dec, DeepEquals, plaintext)
+
+	// wrong passphrase
+	passphrase[0] = 0
+	dec, err = Decrypt(enc, passphrase)
+	c.Assert(err, NotNil)
+	c.Assert(dec, IsNil)
+}
+
+func (EncryptedSuite) TestTamperedRoundtrip(c *C) {
+	passphrase := []byte("supersecret")
+
+	enc, err := Encrypt(plaintext, passphrase)
+	c.Assert(err, IsNil)
+
+	data := &data{}
+	err = json.Unmarshal(enc, data)
+	c.Assert(err, IsNil)
+
+	data.Ciphertext[0] = ^data.Ciphertext[0]
+
+	enc, _ = json.Marshal(data)
+
+	dec, err := Decrypt(enc, passphrase)
+	c.Assert(err, NotNil)
+	c.Assert(dec, IsNil)
+}
+
+func (EncryptedSuite) TestDecrypt(c *C) {
+	enc := []byte(`{"kdf":{"name":"scrypt","params":{"N":32768,"r":8,"p":1},"salt":"N9a7x5JFGbrtB2uBR81jPwp0eiLR4A7FV3mjVAQrg1g="},"cipher":{"name":"nacl/secretbox","nonce":"2h8HxMmgRfuYdpswZBQaU3xJ1nkA/5Ik"},"ciphertext":"SEW6sUh0jf2wfdjJGPNS9+bkk2uB+Cxamf32zR8XkQ=="}`)
+	passphrase := []byte("supersecret")
+
+	dec, err := Decrypt(enc, passphrase)
+	c.Assert(err, IsNil)
+	c.Assert(dec, DeepEquals, plaintext)
+}
+
+func (EncryptedSuite) TestMarshalUnmarshal(c *C) {
+	passphrase := []byte("supersecret")
+
+	wrapped, err := Marshal(plaintext, passphrase)
+	c.Assert(err, IsNil)
+	c.Assert(wrapped, NotNil)
+
+	var protected []byte
+	err = Unmarshal(wrapped, &protected, passphrase)
+	c.Assert(err, IsNil)
+	c.Assert(protected, DeepEquals, plaintext)
+}
+
+func (EncryptedSuite) TestInvalidKDFSettings(c *C) {
+	passphrase := []byte("supersecret")
+
+	wrapped, err := MarshalWithCustomKDFParameters(plaintext, passphrase, 0)
+	c.Assert(err, IsNil)
+	c.Assert(wrapped, NotNil)
+
+	var protected []byte
+	err = Unmarshal(wrapped, &protected, passphrase)
+	c.Assert(err, IsNil)
+	c.Assert(protected, DeepEquals, plaintext)
+}
+
+func (EncryptedSuite) TestLegacyKDFSettings(c *C) {
+	passphrase := []byte("supersecret")
+
+	wrapped, err := MarshalWithCustomKDFParameters(plaintext, passphrase, Legacy)
+	c.Assert(err, IsNil)
+	c.Assert(wrapped, NotNil)
+
+	var protected []byte
+	err = Unmarshal(wrapped, &protected, passphrase)
+	c.Assert(err, IsNil)
+	c.Assert(protected, DeepEquals, plaintext)
+}
+
+func (EncryptedSuite) TestStandardKDFSettings(c *C) {
+	passphrase := []byte("supersecret")
+
+	wrapped, err := MarshalWithCustomKDFParameters(plaintext, passphrase, Standard)
+	c.Assert(err, IsNil)
+	c.Assert(wrapped, NotNil)
+
+	var protected []byte
+	err = Unmarshal(wrapped, &protected, passphrase)
+	c.Assert(err, IsNil)
+	c.Assert(protected, DeepEquals, plaintext)
+}
+
+func (EncryptedSuite) TestOWASPKDFSettings(c *C) {
+	passphrase := []byte("supersecret")
+
+	wrapped, err := MarshalWithCustomKDFParameters(plaintext, passphrase, OWASP)
+	c.Assert(err, IsNil)
+	c.Assert(wrapped, NotNil)
+
+	var protected []byte
+	err = Unmarshal(wrapped, &protected, passphrase)
+	c.Assert(err, IsNil)
+	c.Assert(protected, DeepEquals, plaintext)
+}
+
+func (EncryptedSuite) TestKDFSettingVectors(c *C) {
+	passphrase := []byte("supersecret")
+
+	for _, v := range kdfVectors {
+		var protected []byte
+		err := Unmarshal(v, &protected, passphrase)
+		c.Assert(err, IsNil)
+		c.Assert(protected, DeepEquals, plaintext)
+	}
+}
+
+func (EncryptedSuite) TestUnsupportedKDFParameters(c *C) {
+	enc := []byte(`{"kdf":{"name":"scrypt","params":{"N":99,"r":99,"p":99},"salt":"cZFcQJdwPhPyhU1R4qkl0qVOIjZd4V/7LYYAavq166k="},"cipher":{"name":"nacl/secretbox","nonce":"7vhRS7j0hEPBWV05skAdgLj81AkGeE7U"},"ciphertext":"6WYU/YSXVbYzl/NzaeAzmjLyfFhOOjLc0d8/GFV0aBFdJvyCcXc="}`)
+	passphrase := []byte("supersecret")
+
+	dec, err := Decrypt(enc, passphrase)
+	c.Assert(err, NotNil)
+	c.Assert(dec, IsNil)
+	c.Assert(strings.Contains(err.Error(), "unsupported scrypt parameters"), Equals, true)
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/crypto v0.11.0
+	gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/crypto v0.11.0
-	gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405
 )
 
 require (


### PR DESCRIPTION
**Description**
The following PR moves the encrypted package from go-tuf to go-sslib along with its tests. 

Once this PR is merged, we can then proceed with deprecating it from go-tuf and updating its dependants. 

**Reasoning**
> The [encrypted](https://github.com/theupdateframework/go-tuf/blob/master/encrypted/encrypted.go) package in go-tuf provides the functionality to encrypt/decrypt a given byte stream with another.
>
>This is not relevant to the goal of the project and TUF in general. As a result, there are now projects which have go-tuf as their dependency only because of that.
>
>In that sense, I think it would be right if this package is gradually deprecated here and moved to another project which better suits its functionality.

**Reference**

- https://github.com/theupdateframework/go-tuf/issues/476