### PR TITLE
Use Signer interface in EnvelopeSigner

### DIFF
--- a/dsse/sign.go
+++ b/dsse/sign.go
@@ -15,29 +15,19 @@ var ErrNoSigners = errors.New("no signers provided")
 
 // EnvelopeSigner creates signed Envelopes.
 type EnvelopeSigner struct {
-	providers []SignerVerifier
+	providers []Signer
 }
 
 /*
 NewEnvelopeSigner creates an EnvelopeSigner that uses 1+ Signer algorithms to
-sign the data. Creates a verifier with threshold=1, at least one of the
-providers must validate signatures successfully.
+sign the data.
 */
-func NewEnvelopeSigner(p ...SignerVerifier) (*EnvelopeSigner, error) {
-	return NewMultiEnvelopeSigner(1, p...)
-}
+func NewEnvelopeSigner(p ...Signer) (*EnvelopeSigner, error) {
+	var providers []Signer
 
-/*
-NewMultiEnvelopeSigner creates an EnvelopeSigner that uses 1+ Signer
-algorithms to sign the data. Creates a verifier with threshold. Threshold
-indicates the amount of providers that must validate the envelope.
-*/
-func NewMultiEnvelopeSigner(threshold int, p ...SignerVerifier) (*EnvelopeSigner, error) {
-	var providers []SignerVerifier
-
-	for _, sv := range p {
-		if sv != nil {
-			providers = append(providers, sv)
+	for _, s := range p {
+		if s != nil {
+			providers = append(providers, s)
 		}
 	}
 

--- a/dsse/sign.go
+++ b/dsse/sign.go
@@ -41,6 +41,17 @@ func NewEnvelopeSigner(p ...Signer) (*EnvelopeSigner, error) {
 }
 
 /*
+NewMultiEnvelopeSigner creates an EnvelopeSigner that uses 1+ Signer
+algorithms to sign the data. The threshold parameter is legacy and is ignored.
+
+Deprecated: This function simply calls NewEnvelopeSigner, and that function should
+be preferred.
+*/
+func NewMultiEnvelopeSigner(threshold int, p ...Signer) (*EnvelopeSigner, error) {
+	return NewEnvelopeSigner(p...)
+}
+
+/*
 SignPayload signs a payload and payload type according to DSSE.
 Returned is an envelope as defined here:
 https://github.com/secure-systems-lab/dsse/blob/master/envelope.md

--- a/dsse/sign_test.go
+++ b/dsse/sign_test.go
@@ -172,7 +172,7 @@ func TestNoSigners(t *testing.T) {
 	})
 
 	t.Run("empty slice", func(t *testing.T) {
-		signer, err := NewEnvelopeSigner([]SignerVerifier{}...)
+		signer, err := NewEnvelopeSigner([]Signer{}...)
 		assert.Nil(t, signer, "unexpected signer")
 		assert.NotNil(t, err, "error expected")
 		assert.Equal(t, ErrNoSigners, err, "wrong error")

--- a/dsse/verify_test.go
+++ b/dsse/verify_test.go
@@ -118,7 +118,7 @@ func TestVerifyMultipleProviderThreshold(t *testing.T) {
 
 	var ns nilSignerVerifier
 	var null nullSignerVerifier
-	signer, err := NewMultiEnvelopeSigner(2, ns, null)
+	signer, err := NewEnvelopeSigner(ns, null)
 	assert.Nil(t, err)
 	env, err := signer.SignPayload(context.TODO(), payloadType, []byte(payload))
 	assert.Nil(t, err, "sign failed")


### PR DESCRIPTION
We shouldn't need a Verifier to sign. Also remove unused threshold parameter.
