### PR TITLE
actions: Add Go 1.21, remove coveralls reporting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.19.x, 1.20.x]
+        go-version: [1.18.x, 1.19.x, 1.20.x, 1.21.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -18,14 +18,7 @@ jobs:
       if: runner.os == 'Linux'
       run: test -z $(go fmt ./...)
     - name: Test
-      run: go test -covermode atomic -coverprofile='profile.cov' ./...
-    - name: Send coverage
-      if: runner.os == 'Linux'
-      env:
-        COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        GO111MODULE=off go get github.com/mattn/goveralls
-        $(go env GOPATH)/bin/goveralls -coverprofile=profile.cov -service=github
+      run: go test -v ./...
   staticcheck:
     name: "Run staticcheck"
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should fix some recent test failures. The original action yml included coverage integration we don't actually use in this repository. Mea culpa!