### PR TITLE
Support sigstore fields in public key

### DIFF
--- a/signerverifier/signerverifier.go
+++ b/signerverifier/signerverifier.go
@@ -29,6 +29,8 @@ type SSLibKey struct {
 
 type KeyVal struct {
 	Private     string `json:"private,omitempty"`
-	Public      string `json:"public"`
+	Public      string `json:"public,omitempty"`
 	Certificate string `json:"certificate,omitempty"`
+	Identity    string `json:"identity,omitempty"`
+	Issuer      string `json:"issuer,omitempty"`
 }


### PR DESCRIPTION
This doesn't yet have a signerverifier for sigstore but allows a sigstore identity to be specified in metadata.