### PR TITLE
Move hexDecode test helper into a test file

### DIFF
--- a/signerverifier/utils.go
+++ b/signerverifier/utils.go
@@ -8,7 +8,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"hash"
-	"testing"
 
 	"github.com/secure-systems-lab/go-securesystemslib/cjson"
 )
@@ -140,13 +139,4 @@ func parsePEMKey(data []byte) (any, error) {
 func hashBeforeSigning(data []byte, h hash.Hash) []byte {
 	h.Write(data)
 	return h.Sum(nil)
-}
-
-func hexDecode(t *testing.T, data string) []byte {
-	t.Helper()
-	b, err := hex.DecodeString(data)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return b
 }

--- a/signerverifier/utils_test.go
+++ b/signerverifier/utils_test.go
@@ -1,12 +1,22 @@
 package signerverifier
 
 import (
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func hexDecode(t *testing.T, data string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
 
 func TestLoadKeyFromSSLibBytes(t *testing.T) {
 	t.Run("RSA public key", func(t *testing.T) {


### PR DESCRIPTION
The inclusion of the test helper outside of a _test.go file results in any downstream consumer of this library, either directly or transitively, having the testing package reachable in their binaries. See the following dependency tree for an example which shows how `testing` ends up being included in `github.com/sigstore/sigstore-go`.

```bash
 goda tree "reach(github.com/sigstore/sigstore-go/pkg/tlog...:all,  testing)"
  ├ github.com/sigstore/sigstore-go/pkg/tlog
    ├ github.com/sigstore/rekor/pkg/types/dsse/v0.0.1
      └ github.com/in-toto/in-toto-golang/in_toto
        └ github.com/secure-systems-lab/go-securesystemslib/signerverifier
    └ github.com/sigstore/rekor/pkg/types/intoto/v0.0.2
      └ github.com/in-toto/in-toto-golang/in_toto ~
```

Since the hexDecode helper was only being consumed in tests it was relocated from signerverifier/utils.go to signerverifier/utils_test.go.