### PR TITLE
ci: Update workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,12 @@
 on: [push, pull_request]
 name: build
+permissions:
+  contents: read
 jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.24.x, 1.25.x]
+        go-version: [1.25.x, 1.26.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/secure-systems-lab/go-securesystemslib
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb


### PR DESCRIPTION
This bumps the Go versions in the workflows now that Go 1.26 is released, as well as locks down the permissions for the build workflow.