### PR TITLE
Reduce memory allocation overhead in DSSE verification

### DIFF
--- a/dsse/envelope.go
+++ b/dsse/envelope.go
@@ -1,8 +1,10 @@
 package dsse
 
 import (
+	"bytes"
 	"encoding/base64"
 	"fmt"
+	"strconv"
 )
 
 /*
@@ -42,9 +44,27 @@ PAE implements the DSSE Pre-Authentic Encoding
 https://github.com/secure-systems-lab/dsse/blob/master/protocol.md#signature-definition
 */
 func PAE(payloadType string, payload []byte) []byte {
-	return []byte(fmt.Sprintf("DSSEv1 %d %s %d %s",
-		len(payloadType), payloadType,
-		len(payload), payload))
+	// Pre-size to avoid reallocation. Previously fmt.Sprintf copied payload
+	// into a string and []byte(...) copied it again.
+	const prefix = "DSSEv1 "
+	const sep = " "
+	// Max decimal digits for a non-negative int (len() result) on any
+	// platform: len("9223372036854775807") == 19. Grow is a hint, so a
+	// slight overestimate is harmless.
+	const maxDecimalLen = 19
+	var b bytes.Buffer
+	b.Grow(len(prefix) +
+		maxDecimalLen + len(sep) + len(payloadType) + len(sep) +
+		maxDecimalLen + len(sep) + len(payload))
+	b.WriteString(prefix)
+	b.WriteString(strconv.Itoa(len(payloadType)))
+	b.WriteByte(' ')
+	b.WriteString(payloadType)
+	b.WriteByte(' ')
+	b.WriteString(strconv.Itoa(len(payload)))
+	b.WriteByte(' ')
+	b.Write(payload)
+	return b.Bytes()
 }
 
 /*

--- a/dsse/sign_test.go
+++ b/dsse/sign_test.go
@@ -1,10 +1,12 @@
 package dsse
 
 import (
+	"bytes"
 	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"errors"
@@ -37,6 +39,31 @@ func TestPAE(t *testing.T) {
 		got := PAE("http://example.com/HelloWorld", []byte("ಠ"))
 		assert.Equal(t, want, got, "Wrong encoding")
 	})
+	t.Run("Matches Sprintf reference", func(t *testing.T) {
+		// Ensure the bytes.Buffer implementation produces output
+		// byte-identical to the original fmt.Sprintf implementation.
+		payloadType := "application/vnd.in-toto+json"
+		payload := make([]byte, 1024)
+		_, err := rand.Read(payload)
+		assert.Nil(t, err)
+
+		want := []byte(fmt.Sprintf("DSSEv1 %d %s %d %s",
+			len(payloadType), payloadType,
+			len(payload), payload))
+		got := PAE(payloadType, payload)
+		assert.True(t, bytes.Equal(want, got), "PAE output diverges from Sprintf reference")
+	})
+}
+
+func BenchmarkPAE(b *testing.B) {
+	payloadType := "application/vnd.in-toto+json"
+	payload := make([]byte, 1<<20) // 1 MB
+	_, _ = rand.Read(payload)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = PAE(payloadType, payload)
+	}
 }
 
 type nilSignerVerifier int

--- a/dsse/verify.go
+++ b/dsse/verify.go
@@ -24,18 +24,26 @@ type AcceptedKey struct {
 }
 
 func (ev *EnvelopeVerifier) Verify(ctx context.Context, e *Envelope) ([]AcceptedKey, error) {
+	keys, _, err := ev.VerifyAndDecode(ctx, e)
+	return keys, err
+}
+
+// VerifyAndDecode behaves identically to Verify but also returns the decoded
+// envelope payload, allowing callers who need the payload bytes (e.g., for
+// hashing or further parsing) to avoid a second base64 decode.
+func (ev *EnvelopeVerifier) VerifyAndDecode(ctx context.Context, e *Envelope) ([]AcceptedKey, []byte, error) {
 	if e == nil {
-		return nil, errors.New("cannot verify a nil envelope")
+		return nil, nil, errors.New("cannot verify a nil envelope")
 	}
 
 	if len(e.Signatures) == 0 {
-		return nil, ErrNoSignature
+		return nil, nil, ErrNoSignature
 	}
 
 	// Decode payload (i.e serialized body)
 	body, err := e.DecodeB64Payload()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	// Generate PAE(payloadtype, serialized body)
 	paeEnc := PAE(e.PayloadType, body)
@@ -48,7 +56,7 @@ func (ev *EnvelopeVerifier) Verify(ctx context.Context, e *Envelope) ([]Accepted
 	for _, s := range e.Signatures {
 		sig, err := b64Decode(s.Sig)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		// Loop over the providers.
@@ -97,14 +105,14 @@ func (ev *EnvelopeVerifier) Verify(ctx context.Context, e *Envelope) ([]Accepted
 
 	// Sanity if with some reflect magic this happens.
 	if ev.threshold <= 0 || ev.threshold > len(ev.providers) {
-		return nil, errors.New("invalid threshold")
+		return nil, nil, errors.New("invalid threshold")
 	}
 
 	if len(usedKeyids) < ev.threshold {
-		return acceptedKeys, fmt.Errorf("accepted signatures do not match threshold, Found: %d, Expected %d", len(acceptedKeys), ev.threshold)
+		return acceptedKeys, nil, fmt.Errorf("accepted signatures do not match threshold, Found: %d, Expected %d", len(acceptedKeys), ev.threshold)
 	}
 
-	return acceptedKeys, nil
+	return acceptedKeys, body, nil
 }
 
 func NewEnvelopeVerifier(v ...Verifier) (*EnvelopeVerifier, error) {

--- a/dsse/verify_test.go
+++ b/dsse/verify_test.go
@@ -92,6 +92,31 @@ func TestVerifyOneProvider(t *testing.T) {
 	assert.Equal(t, acceptedKeys[0].KeyID, "nil", "unexpected keyid")
 }
 
+func TestVerifyAndDecode(t *testing.T) {
+	var payloadType = "http://example.com/HelloWorld"
+	var payload = "hello world"
+
+	var ns nilSignerVerifier
+	signer, err := NewEnvelopeSigner(ns)
+	assert.Nil(t, err, "unexpected error")
+
+	env, err := signer.SignPayload(context.TODO(), payloadType, []byte(payload))
+	assert.Nil(t, err, "sign failed")
+
+	verifier, err := NewEnvelopeVerifier(ns)
+	assert.Nil(t, err, "unexpected error")
+	acceptedKeys, body, err := verifier.VerifyAndDecode(context.TODO(), env)
+	assert.Nil(t, err, "unexpected error")
+	assert.Len(t, acceptedKeys, 1, "unexpected keys")
+	assert.Equal(t, acceptedKeys[0].KeyID, "nil", "unexpected keyid")
+
+	// Returned body must match a fresh DecodeB64Payload on the same envelope.
+	want, err := env.DecodeB64Payload()
+	assert.Nil(t, err, "unexpected error")
+	assert.Equal(t, want, body, "decoded body mismatch")
+	assert.Equal(t, []byte(payload), body, "decoded body does not match original payload")
+}
+
 func TestVerifyMultipleProvider(t *testing.T) {
 	var payloadType = "http://example.com/HelloWorld"
 	var payload = "hello world"


### PR DESCRIPTION
Two backward-compatible changes targeting large-payload envelopes (as in-toto attestations can be tens of MB).

### `PAE`: build with pre-sized `bytes.Buffer`

The previous `fmt.Sprintf("... %s", payload)` copies the `[]byte` payload into the format buffer, then `[]byte(result)` copies the whole string again. Switched to a single `bytes.Buffer.Grow` + `Write`. Output is byte-identical (verified by a new test against the Sprintf reference).

`BenchmarkPAE`, 1 MB payload:

|        | ns/op    | B/op      | allocs/op |
|--------|----------|-----------|-----------|
| before | 1069238  | 2114959   | 8         |
| after  |  762502  | 1056780   | 2         |
| delta  | **-29%** | **-50%**  | **-75%**  |

### `EnvelopeVerifier.VerifyAndDecode`

`Verify` already decodes the payload internally to build the PAE, then discards it. Callers that need the payload bytes (Rekor hashes it for index keys) currently call `DecodeB64Payload()` again — a second 10 MB allocation for a 10 MB payload.

`VerifyAndDecode` returns the already-decoded body alongside the accepted keys. `Verify` is now a thin wrapper around it; signature and behavior unchanged.